### PR TITLE
Rename command to `handlebars-render` to avoid PATH conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "handlebars-cmd",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "bin": {
-    "handlebars": "index.js"
+    "handlebars-render": "index.js"
   },
   "description": "Invoke handlebars from the command line",
   "main": "index.js",


### PR DESCRIPTION
Right now if your project has both `handlebars` and `handlebars-cmd` installed, they both try and register an executable called `handlebars`. This PR renames this binary to `handlebars-render`.
